### PR TITLE
feat: Add getBunaryConfig() and support for ORM configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to `@bunary/core` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.3] - 2026-01-26
+
+### Added
+
+- `Environment` constant object with `DEVELOPMENT`, `PRODUCTION`, and `TEST` values
+- `EnvironmentType` type export for environment type safety
+
 ## [0.0.2] - 2026-01-24
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bunary/core",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Foundation module for Bunary - config, environment, and app helpers",
   "type": "module",
   "main": "./dist/index.js",
@@ -30,6 +30,14 @@
   ],
   "author": "Paul Radford",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bunary-dev/core.git"
+  },
+  "homepage": "https://github.com/bunary-dev/core#readme",
+  "bugs": {
+    "url": "https://github.com/bunary-dev/core/issues"
+  },
   "engines": {
     "bun": ">=1.0.0"
   },

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,8 @@
 import { Environment } from "./constants.js";
 import type { BunaryConfig } from "./types";
 
+let globalBunaryConfig: BunaryConfig | null = null;
+
 /**
  * Define Bunary configuration with type safety
  *
@@ -13,11 +15,17 @@ import type { BunaryConfig } from "./types";
  *     name: "MyApp",
  *     env: "development",
  *   },
+ *   orm: {
+ *     database: {
+ *       type: "sqlite",
+ *       sqlite: { path: "./database.sqlite" }
+ *     }
+ *   }
  * });
  * ```
  */
 export function defineConfig(config: BunaryConfig): BunaryConfig {
-  return {
+  const validated: BunaryConfig = {
     app: {
       name: config.app.name,
       env:
@@ -27,4 +35,34 @@ export function defineConfig(config: BunaryConfig): BunaryConfig {
       debug: config.app.debug ?? Bun.env.DEBUG === "true",
     },
   };
+
+  // Include ORM config if provided (from @bunary/orm)
+  if (config.orm) {
+    validated.orm = config.orm;
+  }
+
+  globalBunaryConfig = validated;
+  return validated;
+}
+
+/**
+ * Get the global Bunary configuration
+ *
+ * @returns The current Bunary configuration
+ * @throws If configuration has not been set
+ */
+export function getBunaryConfig(): BunaryConfig {
+  if (!globalBunaryConfig) {
+    throw new Error("Bunary configuration not set. Call defineConfig() first.");
+  }
+  return globalBunaryConfig;
+}
+
+/**
+ * Clear the global Bunary configuration (useful for testing)
+ *
+ * @internal
+ */
+export function clearBunaryConfig(): void {
+  globalBunaryConfig = null;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@
  * Foundation module for Bunary - config, environment, and app helpers
  */
 
-export { defineConfig } from "./config";
+export { defineConfig, getBunaryConfig, clearBunaryConfig } from "./config";
 export { Environment, type EnvironmentType } from "./constants";
 export { env, isDev, isProd, isTest } from "./environment";
-export type { BunaryConfig, AppConfig } from "./types";
+export type { BunaryConfig, AppConfig, OrmConfig } from "./types";

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,8 +13,30 @@ export interface AppConfig {
 }
 
 /**
+ * ORM configuration type (matches @bunary/orm OrmConfig)
+ * Defined here to avoid circular dependency
+ */
+export interface OrmConfig {
+  database: {
+    type: "sqlite" | "mysql" | "postgres";
+    sqlite?: {
+      path: string;
+    };
+    mysql?: {
+      host: string;
+      port?: number;
+      user: string;
+      password: string;
+      database: string;
+    };
+  };
+}
+
+/**
  * Root Bunary configuration
  */
 export interface BunaryConfig {
   app: AppConfig;
+  /** Optional ORM configuration (from @bunary/orm) */
+  orm?: OrmConfig;
 }


### PR DESCRIPTION
This PR adds support for ORM configuration in @bunary/core to enable @bunary/orm to read its configuration from the core config.

## Changes

- Export `getBunaryConfig()` function to retrieve global Bunary configuration
- Add `OrmConfig` type definition in core (to avoid circular dependency with @bunary/orm)
- Update `BunaryConfig` interface to include optional `orm` property
- Export `OrmConfig` type from index.ts
- Update CHANGELOG.md
- Bump version to 0.0.4 (0.0.3 already published on npm)

## Benefits

- Enables unified configuration approach
- Allows ORM to read config from core without hardcoding
- Maintains package boundaries (no circular dependencies)

Closes #11