### PR TITLE
chore: Bump version to 0.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bunary/core",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Foundation module for Bunary - config, environment, and app helpers",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Bump package version to 0.0.5 to include the global registry fix for cross-package config access.

## Changes
- Version bump: 0.0.4 → 0.0.5

## Includes
- Global registry (`__bunaryCoreConfig`) for cross-package config access
- Allows @bunary/orm to read configuration from @bunary/core reliably

Closes #13