### PR TITLE
fix: add postgres config shape to OrmConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to `@bunary/core` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.7] - 2026-01-27
+
+### Fixed
+
+- Added missing `postgres` config shape to `OrmConfig` to match the declared database type union
+
 ## [0.0.6] - 2026-01-27
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bunary/core",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Foundation module for Bunary - config, environment, and app helpers",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,13 @@ export interface OrmConfig {
       password: string;
       database: string;
     };
+    postgres?: {
+      host: string;
+      port?: number;
+      user: string;
+      password: string;
+      database: string;
+    };
   };
 }
 


### PR DESCRIPTION
## Summary
- Adds the missing `postgres` config shape to `OrmConfig` so the type union is internally consistent.
- Bumps `@bunary/core` to 0.0.7 and updates the changelog.

## Notes
This change does not imply full Postgres driver support in `@bunary/orm`; it only fixes the core config typing so consumers can represent Postgres config when needed.

## Test plan
- `bun test`
- `bun run typecheck`
- `bun run lint`

Closes #18