### PR TITLE
chore: release 0.1.0 - first minor release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to `@bunary/core` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0] - 2026-01-31
+
+### Added
+
+- First minor release — API stable for production use
+
 ## [0.0.7] - 2026-01-27
 
 ### Fixed

--- a/biome.json
+++ b/biome.json
@@ -1,8 +1,6 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
-  "organizeImports": {
-    "enabled": true
-  },
+  "$schema": "https://biomejs.dev/schemas/2.3.13/schema.json",
+  "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "linter": {
     "enabled": true,
     "rules": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bunary/core",
-  "version": "0.0.7",
+  "version": "0.1.0",
   "description": "Foundation module for Bunary - config, environment, and app helpers",
   "type": "module",
   "main": "./dist/index.js",
@@ -42,7 +42,7 @@
     "bun": ">=1.0.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^1.9.4",
+    "@biomejs/biome": "^2.3.13",
     "bun-types": "latest"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,11 +4,11 @@
  */
 
 export {
+  clearBunaryConfig,
   createConfig,
   defineConfig,
   getBunaryConfig,
-  clearBunaryConfig,
 } from "./config";
 export { Environment, type EnvironmentType } from "./constants";
 export { env, isDev, isProd, isTest } from "./environment";
-export type { BunaryConfig, AppConfig, OrmConfig } from "./types";
+export type { AppConfig, BunaryConfig, OrmConfig } from "./types";


### PR DESCRIPTION
Closes #31

## Changes
- Bump version to 0.1.0
- Update CHANGELOG: first minor release — API stable for production use
- No dependencies to update