### PR TITLE
feat: harden config store — has(), freeze, validation, module augmentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to `@bunary/core` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-02-15
+
+### Added
+
+- `has()` method on `BunaryConfigStore` — check if config is set without try/catch (#36)
+- `get()` now returns a shallow-frozen `Readonly<BunaryConfig>` to prevent accidental mutation (#35)
+- Runtime validation: `defineConfig()` throws if `app.name` is empty or whitespace-only (#37)
+- Tests for module augmentation property passthrough (#38)
+
+### Changed
+
+- Removed duplicated `OrmConfig` type — config extensibility via module augmentation instead
+- `defineConfig()` uses spread to pass through augmented properties (e.g. `orm` from `@bunary/orm`)
+- `BunaryConfigStore.get()` return type is now `Readonly<BunaryConfig>`
+
 ## [0.1.0] - 2026-01-31
 
 ### Added

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,11 +64,14 @@ Returns true if NODE_ENV is "test".
 
 ### defineConfig(config: BunaryConfig): BunaryConfig
 
-Type-safe configuration helper with defaults.
+Type-safe configuration helper with defaults. Validates `app.name` is non-empty. Passes through any augmented properties (e.g. `orm` from `@bunary/orm`).
 
 ### createConfig(config?: BunaryConfig): BunaryConfigStore
 
-Create an instance-scoped configuration store with `get()`, `set()`, and `clear()`.
+Create an instance-scoped configuration store with `get()`, `set()`, `has()`, and `clear()`.
+
+- `get()` returns a shallow-frozen `Readonly<BunaryConfig>` to prevent accidental mutation.
+- `has()` returns `true` if config has been set and not cleared.
 
 ## Requirements
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bunary/core",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Foundation module for Bunary - config, environment, and app helpers",
   "type": "module",
   "main": "./dist/index.js",
@@ -42,7 +42,7 @@
     "bun": ">=1.0.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.3.13",
+    "@biomejs/biome": "2.3.15",
     "bun-types": "latest"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,4 +11,4 @@ export {
 } from "./config";
 export { Environment, type EnvironmentType } from "./constants";
 export { env, isDev, isProd, isTest } from "./environment";
-export type { AppConfig, BunaryConfig, OrmConfig } from "./types";
+export type { AppConfig, BunaryConfig } from "./types";

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,37 +13,22 @@ export interface AppConfig {
 }
 
 /**
- * ORM configuration type (matches @bunary/orm OrmConfig)
- * Defined here to avoid circular dependency
- */
-export interface OrmConfig {
-  database: {
-    type: "sqlite" | "mysql" | "postgres";
-    sqlite?: {
-      path: string;
-    };
-    mysql?: {
-      host: string;
-      port?: number;
-      user: string;
-      password: string;
-      database: string;
-    };
-    postgres?: {
-      host: string;
-      port?: number;
-      user: string;
-      password: string;
-      database: string;
-    };
-  };
-}
-
-/**
  * Root Bunary configuration
+ *
+ * This interface is extended by other packages via module augmentation:
+ * - @bunary/orm adds `orm?: OrmConfig`
+ * - @bunary/http adds `http?: HttpConfig` (future)
+ *
+ * @example
+ * ```ts
+ * // In @bunary/orm:
+ * declare module "@bunary/core" {
+ *   interface BunaryConfig {
+ *     orm?: OrmConfig;
+ *   }
+ * }
+ * ```
  */
 export interface BunaryConfig {
   app: AppConfig;
-  /** Optional ORM configuration (from @bunary/orm) */
-  orm?: OrmConfig;
 }


### PR DESCRIPTION
## Summary

Harden the `BunaryConfigStore` with immutability, introspection, validation, and extensibility via module augmentation.

Closes #35, Closes #36, Closes #37, Closes #38

## Changes

### Features
- **`has()` method** (#36) — check if config is set without try/catch
- **Immutable `get()`** (#35) — returns a shallow-frozen `Readonly<BunaryConfig>` to prevent accidental mutation
- **`app.name` validation** (#37) — `defineConfig()` throws if `app.name` is empty or whitespace-only

### Refactors
- **Module augmentation** — removed duplicated `OrmConfig` type from core. Other packages (e.g. `@bunary/orm`) now extend `BunaryConfig` via `declare module "@bunary/core"` instead of core duplicating their types
- **Spread passthrough** — `defineConfig()` uses `{ app, ...rest }` destructuring to pass through any augmented properties

### Tests (#38)
- Augmented property passthrough through `defineConfig()` and `createConfig()`
- Mutation safety (`Object.isFrozen`, assignment throws)
- `has()` state transitions (false → set → true → clear → false)
- Empty/whitespace `app.name` rejection

## Verification

- `bun run typecheck` ✅
- `bun run lint` ✅  
- `bun test` — 54/54 pass ✅
- `@bunary/orm` typecheck + 219/219 tests ✅ (cross-package validation)